### PR TITLE
Remove extraneous lines from roles/server.json

### DIFF
--- a/roles/server.json
+++ b/roles/server.json
@@ -54,8 +54,6 @@
     "sudo",
     // lock down ssh, install firewall etc
     "basic-security-tlq",
-    // get monit up and running (config is down to
-    // individual apps/ a separate recipe)    "monitoring",
     // make the server look pretty
     "look-and-feel-tlq",
     // get monit up and running (config is down to


### PR DESCRIPTION
There were a couple lines that appear to be duplicates of the "monit-tlq" cookbook. The
only difference is that they reference a "monitoring" cookbook which does not appear to
exist in the project. Removed the lines to eliminate confusion later.
