### PR TITLE
Fixes nginx role name

### DIFF
--- a/nodes/rails_postgres_redis.json.example
+++ b/nodes/rails_postgres_redis.json.example
@@ -54,7 +54,7 @@
   "run_list":
   [
     "role[server]",
-    "role[nginx]",
+    "role[nginx-server]",
     "role[postgres-server]",
     "role[rails-app]",
     "role[redis-server]"


### PR DESCRIPTION
There is no role with `nginx` name. I think there should be `nginx-server`
