### PR TITLE
Use nginx-server not nginx

### DIFF
--- a/nodes/rails_postgres_redis.json.example
+++ b/nodes/rails_postgres_redis.json.example
@@ -54,7 +54,7 @@
   "run_list":
   [
     "role[server]",
-    "role[nginx]",
+    "role[nginx-server]",
     "role[postgres-server]",
     "role[rails-app]",
     "role[redis-server]"


### PR DESCRIPTION
I followed along with the quick start, but got an error about no "nginx" role
existing. Turns out it should be nginx-server (as it is in the other node
file).

Changing this allowed my `bundle exec knife solo bootstrap root@YOURSERVERIP`
command to run.
