### PR TITLE
Use notify_emails as json key for monit config

### DIFF
--- a/nodes/rails-postgres-redis1.json
+++ b/nodes/rails-postgres-redis1.json
@@ -29,7 +29,7 @@
     }
   },
   "monit": {
-    "notify_email" : ["email@example.com"],
+    "notify_emails" : ["email@example.com"],
     "enable_emails" : false,
     "web_interface" : {
       // the plaintext monit username and password

--- a/nodes/rails_postgres_redis.json.example
+++ b/nodes/rails_postgres_redis.json.example
@@ -21,7 +21,7 @@
       "password" : "REPLACE",
       "hostname" : "REPLACE"
     },
-    "notify_email" : ["REPLACE@example.com"],
+    "notify_emails" : ["REPLACE@example.com"],
     "web_interface" : {
       // the plaintext monit username and password
       "allow" : ["REPLACE(USERNAME)","REPLACE(PASSWORD)"]


### PR DESCRIPTION
## What's Up??
I used the rails-server-template to set up a node. After successfully running the script, I later realized that email notifications for monit weren't working correctly. I looked into it some more and it turns out that the key `notify_email` doesn't exist in `monit-tlq` as it's actually called [`notify_emails`](https://github.com/TalkingQuickly/monit-tlq/blob/master/attributes/default.rb#L1). 

## What this does
This changes the key definition for both of the json files in the `nodes` directory. Note that the key was already correct in [`roles/server.json`](https://github.com/TalkingQuickly/rails-server-template/blob/master/roles/server.json#L42) so I did not have to update that.