### PR TITLE
added openssh recipe to server role

### DIFF
--- a/roles/server.json
+++ b/roles/server.json
@@ -79,6 +79,8 @@
     "recipe[chef-solo-search::default]",
     // setup standard sysadmin users
     "recipe[users::sysadmins]",
+    // change server access authorizations
+    "recipe[openssh::default]",
     // install and enable ufw
     "recipe[ufw::default]",
     // enable unattended upgrades


### PR DESCRIPTION
I realised that the sshd_config file never changed on my vps so I checked the server role and realised that the opensshd recipe wasn't included.
