### PR TITLE
fixes cosmetic comment typo in node def

### DIFF
--- a/nodes/rails-postgres-redis1.json
+++ b/nodes/rails-postgres-redis1.json
@@ -5,7 +5,7 @@
       // the deploy user specifically gets sudo rights
       // if you're using vagrant it's worth adding "vagrant"
       // to this array
-      // The password for the dpeloy user is set in data_bags/users/deploy.json
+      // The password for the deploy user is set in data_bags/users/deploy.json
       // and should be generated using:
       // openssl passwd -1 "plaintextpassword"
       "users": ["deploy", "vagrant"]


### PR DESCRIPTION
nodes/rails-postgres-redis1.json had 'deploy' misspelled in the comments.  Could not be more minor.  So minor I didn't bother to even create a feature branch.  Lazy, I know.
